### PR TITLE
test: increase application/export coverage to 90%

### DIFF
--- a/internal/application/export/export_test.go
+++ b/internal/application/export/export_test.go
@@ -85,6 +85,51 @@ func TestUseCase_ExportCSV(t *testing.T) {
 			filters: export.CSVFilters{},
 			wantCSV: "date,type,amount,category,account,description\n2026-02-28,expense,50.00,Uncategorized,Unknown,Groceries\n",
 		},
+		{
+			name: "filters by income type",
+			repo: buildMockRepoForCSVWithType(
+				[]domainaccount.Account{{ID: "acc-1", Name: "Banco"}},
+				[]domaincategory.Category{},
+				[]domaintransaction.Transaction{
+					buildIncome("tx-1", 1000.00, "acc-1", "Salary"),
+				},
+				nil,
+				"income",
+			),
+			filters: export.CSVFilters{Type: "income"},
+			wantCSV: "date,type,amount,category,account,description\n2026-02-28,income,1000.00,Income,Banco,Salary\n",
+		},
+		{
+			name: "filters by expense type",
+			repo: buildMockRepoForCSVWithType(
+				[]domainaccount.Account{{ID: "acc-1", Name: "Banco"}},
+				[]domaincategory.Category{{ID: "cat-1", Name: "Food"}},
+				[]domaintransaction.Transaction{
+					buildExpense("tx-1", 50.00, "acc-1", "cat-1", "Groceries"),
+				},
+				nil,
+				"expense",
+			),
+			filters: export.CSVFilters{Type: "expense"},
+			wantCSV: "date,type,amount,category,account,description\n2026-02-28,expense,50.00,Food,Banco,Groceries\n",
+		},
+		{
+			name: "exports empty CSV when no transactions",
+			repo: buildMockRepoForCSV(
+				[]domainaccount.Account{{ID: "acc-1", Name: "Banco"}},
+				[]domaincategory.Category{},
+				[]domaintransaction.Transaction{},
+				nil,
+			),
+			filters: export.CSVFilters{},
+			wantCSV: "date,type,amount,category,account,description\n",
+		},
+		{
+			name:    "categories error is propagated",
+			repo:    buildMockRepoForCSVWithCategoriesError(),
+			filters: export.CSVFilters{},
+			wantErr: fmt.Errorf("export csv: %w", errors.New("categories error")),
+		},
 	}
 
 	for _, tc := range tests {
@@ -145,6 +190,31 @@ func TestUseCase_ExportJSON(t *testing.T) {
 			name:    "repository error is propagated",
 			repo:    buildMockRepoForJSON(nil, nil, nil, nil, errors.New("db error")),
 			wantErr: fmt.Errorf("export json: %w", errors.New("db error")),
+		},
+		{
+			name:    "categories error is propagated",
+			repo:    buildMockRepoForJSONWithCategoriesError(),
+			wantErr: fmt.Errorf("export json: %w", errors.New("categories error")),
+		},
+		{
+			name:    "expenses error is propagated",
+			repo:    buildMockRepoForJSONWithExpensesError(),
+			wantErr: fmt.Errorf("export json: %w", errors.New("expenses error")),
+		},
+		{
+			name: "exports empty JSON with empty data",
+			repo: buildMockRepoForJSON(
+				[]domainaccount.Account{},
+				[]domaincategory.Category{},
+				[]domaintransaction.Transaction{},
+				[]domaintransaction.Transaction{},
+				nil,
+			),
+			wantContains: []string{
+				`"accounts": []`,
+				`"categories": []`,
+				`"transactions": []`,
+			},
 		},
 	}
 

--- a/internal/application/export/testdata_test.go
+++ b/internal/application/export/testdata_test.go
@@ -1,6 +1,8 @@
 package export_test
 
 import (
+	"errors"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/financial-manager/api/internal/application/export/mocks"
@@ -30,6 +32,38 @@ func buildMockRepoForCSV(
 	return m
 }
 
+// buildMockRepoForCSVWithType creates a mocks.Repository for CSV export with type filter.
+func buildMockRepoForCSVWithType(
+	accounts []domainaccount.Account,
+	categories []domaincategory.Category,
+	transactions []domaintransaction.Transaction,
+	err error,
+	txType string,
+) *mocks.Repository {
+	m := &mocks.Repository{}
+
+	m.On("ListAccounts", mock.Anything).Return(accounts, nil).Once()
+	m.On("ListCategories", mock.Anything).Return(categories, nil).Once()
+
+	var tType domaintransaction.TransactionType
+	if txType == "income" {
+		tType = domaintransaction.TransactionTypeIncome
+	} else if txType == "expense" {
+		tType = domaintransaction.TransactionTypeExpense
+	}
+	m.On("ListTransactions", mock.Anything, tType, "", "").Return(transactions, err).Once()
+
+	return m
+}
+
+// buildMockRepoForCSVWithCategoriesError creates a mock that returns error on ListCategories.
+func buildMockRepoForCSVWithCategoriesError() *mocks.Repository {
+	m := &mocks.Repository{}
+	m.On("ListAccounts", mock.Anything).Return([]domainaccount.Account{{ID: "acc-1", Name: "Banco"}}, nil).Once()
+	m.On("ListCategories", mock.Anything).Return([]domaincategory.Category(nil), errors.New("categories error")).Once()
+	return m
+}
+
 // buildMockRepoForJSON creates a mocks.Repository pre-configured for JSON export tests.
 func buildMockRepoForJSON(
 	accounts []domainaccount.Account,
@@ -50,5 +84,23 @@ func buildMockRepoForJSON(
 	m.On("ListTransactions", mock.Anything, domaintransaction.TransactionTypeIncome, "", "").Return(incomes, nil).Once()
 	m.On("ListTransactions", mock.Anything, domaintransaction.TransactionTypeExpense, "", "").Return(expenses, nil).Once()
 
+	return m
+}
+
+// buildMockRepoForJSONWithCategoriesError creates a mock that returns error on ListCategories.
+func buildMockRepoForJSONWithCategoriesError() *mocks.Repository {
+	m := &mocks.Repository{}
+	m.On("ListAccounts", mock.Anything).Return([]domainaccount.Account{{ID: "acc-1", Name: "Banco"}}, nil).Once()
+	m.On("ListCategories", mock.Anything).Return([]domaincategory.Category(nil), errors.New("categories error")).Once()
+	return m
+}
+
+// buildMockRepoForJSONWithExpensesError creates a mock that returns error on ListTransactions for expenses.
+func buildMockRepoForJSONWithExpensesError() *mocks.Repository {
+	m := &mocks.Repository{}
+	m.On("ListAccounts", mock.Anything).Return([]domainaccount.Account{{ID: "acc-1", Name: "Banco"}}, nil).Once()
+	m.On("ListCategories", mock.Anything).Return([]domaincategory.Category{{ID: "cat-1", Name: "Food"}}, nil).Once()
+	m.On("ListTransactions", mock.Anything, domaintransaction.TransactionTypeIncome, "", "").Return([]domaintransaction.Transaction{}, nil).Once()
+	m.On("ListTransactions", mock.Anything, domaintransaction.TransactionTypeExpense, "", "").Return([]domaintransaction.Transaction(nil), errors.New("expenses error")).Once()
 	return m
 }


### PR DESCRIPTION
## Summary

Increases test coverage for the application/export package.

## Changes

- **CSV tests added**:
  - Filters by income/expense type
  - Empty CSV when no transactions
  - Categories error propagation

- **JSON tests added**:
  - Categories error propagation
  - Expenses error propagation
  - Empty JSON with empty data

## Coverage

- Before: 81.0%
- After: 89.7% (threshold: 85%)

## Testing

- All tests pass with `-race` detector