### PR TITLE
test: increase account and category repository coverage to 85%

### DIFF
--- a/internal/platform/account/sqlite/repository_test.go
+++ b/internal/platform/account/sqlite/repository_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -118,4 +119,37 @@ func TestAccountRepository_HasTransactions_ReturnsFalse(t *testing.T) {
 	has, err := repo.HasTransactions(context.Background(), "any-id")
 	require.NoError(t, err)
 	assert.False(t, has)
+}
+
+func TestAccountRepository_List_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := accountsqlite.NewAccountRepository(db)
+	_, err = repo.List(context.Background())
+	require.Error(t, err)
+}
+
+func TestAccountRepository_Update_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := accountsqlite.NewAccountRepository(db)
+	err = repo.Update(context.Background(), domainaccount.Account{ID: "test"})
+	require.Error(t, err)
+}
+
+func TestAccountRepository_Delete_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := accountsqlite.NewAccountRepository(db)
+	err = repo.Delete(context.Background(), "test")
+	require.Error(t, err)
 }

--- a/internal/platform/category/sqlite/repository_test.go
+++ b/internal/platform/category/sqlite/repository_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -157,4 +158,48 @@ func TestCategoryRepository_HasTransactions(t *testing.T) {
 	hasTrans, err := repo.HasTransactions(ctx, "any-id")
 	require.NoError(t, err)
 	assert.False(t, hasTrans)
+}
+
+func TestCategoryRepository_List_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := categorysqlite.NewCategoryRepository(db)
+	_, err = repo.List(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestCategoryRepository_Update_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := categorysqlite.NewCategoryRepository(db)
+	err = repo.Update(context.Background(), domaincategory.Category{ID: "test"})
+	require.Error(t, err)
+}
+
+func TestCategoryRepository_Delete_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := categorysqlite.NewCategoryRepository(db)
+	err = repo.Delete(context.Background(), "test")
+	require.Error(t, err)
+}
+
+func TestCategoryRepository_CountAll_QueryError(t *testing.T) {
+	t.Parallel()
+	db, err := sql.Open("sqlite", "file:?mode=invalid")
+	require.NoError(t, err)
+	defer db.Close()
+
+	repo := categorysqlite.NewCategoryRepository(db)
+	_, err = repo.CountAll(context.Background())
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Increases test coverage for the platform/account/sqlite and platform/category/sqlite repositories.

## Changes

- **account/sqlite**: Added query error tests for List, Update, Delete
- **category/sqlite**: Added query error tests for List, Update, Delete, CountAll

## Coverage

| Package | Before | After |
|---------|--------|-------|
| account/sqlite | 83.6% | 89.1% |
| category/sqlite | 84.1% | 89.9% |

Threshold: 85%

## Testing

- All tests pass with `-race` detector