### PR TITLE
fix: handle errors in HTTP response writes (errcheck)

### DIFF
--- a/cmd/api/handlers/dashboard/handler.go
+++ b/cmd/api/handlers/dashboard/handler.go
@@ -4,6 +4,7 @@ package dashboard
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 
 	appDashboard "github.com/financial-manager/api/internal/application/dashboard"
@@ -105,7 +106,9 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("encode response: %v", err)
+	}
 }
 
 // writeError writes an error response.

--- a/cmd/api/handlers/export/handler.go
+++ b/cmd/api/handlers/export/handler.go
@@ -4,6 +4,7 @@ package export
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -47,7 +48,10 @@ func (h *Handler) HandleCSV(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/csv")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(csvData))
+	if _, err := w.Write([]byte(csvData)); err != nil {
+		log.Printf("write csv response: %v", err)
+		return
+	}
 }
 
 // HandleJSON processes GET /api/v1/export/json.
@@ -62,5 +66,8 @@ func (h *Handler) HandleJSON(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.WriteHeader(http.StatusOK)
-	w.Write(jsonData)
+	if _, err := w.Write(jsonData); err != nil {
+		log.Printf("write json response: %v", err)
+		return
+	}
 }

--- a/cmd/api/handlers/export/pdf/handler.go
+++ b/cmd/api/handlers/export/pdf/handler.go
@@ -4,6 +4,7 @@ package pdf
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 
@@ -54,5 +55,8 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/pdf")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
 	w.WriteHeader(http.StatusOK)
-	w.Write(pdfData)
+	if _, err := w.Write(pdfData); err != nil {
+		log.Printf("write pdf response: %v", err)
+		return
+	}
 }


### PR DESCRIPTION
## Summary
- Handle errors in w.Write() calls in all handlers
- Handle errors in json.Encode() calls
- Run errcheck ./... passes with zero issues for critical handlers

## Changes
- cmd/api/handlers/dashboard/handler.go: Handle json.Encode error
- cmd/api/handlers/export/handler.go: Handle w.Write errors in HandleCSV and HandleJSON
- cmd/api/handlers/export/pdf/handler.go: Handle w.Write error

Closes #47