### PR TITLE
fix: resolve errcheck issues in handlers and platform

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,3 @@ issues:
     - path: testdata
       linters:
         - errcheck
-    - path: handlers/
-      linters:
-        - errcheck
-    - path: platform/
-      linters:
-        - errcheck

--- a/cmd/api/handlers/dashboard/handler.go
+++ b/cmd/api/handlers/dashboard/handler.go
@@ -4,6 +4,7 @@ package dashboard
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 
 	appDashboard "github.com/financial-manager/api/internal/application/dashboard"
@@ -105,7 +106,9 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("encode response: %v", err)
+	}
 }
 
 // writeError writes an error response.

--- a/cmd/api/handlers/export/handler.go
+++ b/cmd/api/handlers/export/handler.go
@@ -4,6 +4,7 @@ package export
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -47,7 +48,10 @@ func (h *Handler) HandleCSV(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/csv")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(csvData))
+	if _, err := w.Write([]byte(csvData)); err != nil {
+		log.Printf("write csv response: %v", err)
+		return
+	}
 }
 
 // HandleJSON processes GET /api/v1/export/json.
@@ -62,5 +66,8 @@ func (h *Handler) HandleJSON(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.WriteHeader(http.StatusOK)
-	w.Write(jsonData)
+	if _, err := w.Write(jsonData); err != nil {
+		log.Printf("write json response: %v", err)
+		return
+	}
 }

--- a/cmd/api/handlers/export/pdf/handler.go
+++ b/cmd/api/handlers/export/pdf/handler.go
@@ -4,6 +4,7 @@ package pdf
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 
@@ -54,5 +55,8 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/pdf")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
 	w.WriteHeader(http.StatusOK)
-	w.Write(pdfData)
+	if _, err := w.Write(pdfData); err != nil {
+		log.Printf("write pdf response: %v", err)
+		return
+	}
 }

--- a/internal/platform/transaction/sqlite/repository.go
+++ b/internal/platform/transaction/sqlite/repository.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -32,7 +33,11 @@ func (r *TransactionRepository) Create(ctx context.Context, t domaintransaction.
 	if err != nil {
 		return fmt.Errorf("transaction sqlite: begin: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Printf("rollback: %v", err)
+		}
+	}()
 
 	const insertQ = `INSERT INTO transactions
 		(id, account_id, category_id, type, amount, description, date, is_active, created_at, updated_at)
@@ -119,7 +124,11 @@ func (r *TransactionRepository) SoftDelete(ctx context.Context, id string) error
 	if err != nil {
 		return fmt.Errorf("transaction sqlite: begin: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
+			log.Printf("rollback: %v", err)
+		}
+	}()
 
 	// Get transaction info before deleting
 	const getQ = `SELECT account_id, type, amount FROM transactions WHERE id = ? AND is_active = 1`


### PR DESCRIPTION
## Summary
- Handle errors in w.Write() calls in all handlers
- Handle errors in json.Encode() calls
- Handle errors in tx.Rollback() calls in platform/transaction/sqlite/repository.go
- Remove exclusions for handlers/ and platform/ in .golangci.yml
- make lint now passes without exclusions

## Changes
- cmd/api/handlers/dashboard/handler.go: Handle json.Encode error
- cmd/api/handlers/export/handler.go: Handle w.Write errors in HandleCSV and HandleJSON
- cmd/api/handlers/export/pdf/handler.go: Handle w.Write error
- internal/platform/transaction/sqlite/repository.go: Handle tx.Rollback errors in Create and SoftDelete
- .golangci.yml: Remove errcheck exclusions for handlers/ and platform/

Closes #55